### PR TITLE
external dependency crate change from gcc to cc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ build = "build.rs"
 name = "pdcurses"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0.2"
 
 [dependencies]
 libc = "0.2"

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,11 @@
-extern crate gcc;
+extern crate cc;
 
 fn main() {
     println!("cargo:rustc-link-lib=dylib=gdi32");
     println!("cargo:rustc-link-lib=dylib=comdlg32");
     println!("cargo:rustc-link-lib=dylib=user32");
 
-    gcc::Build::new()
+    cc::Build::new()
         .file("src/PDCurses/pdcurses/addch.c") //Common PDCurses files
         .file("src/PDCurses/pdcurses/addchstr.c")
         .file("src/PDCurses/pdcurses/addstr.c")


### PR DESCRIPTION
Updated dependency on old gcc crate.

It seems that gcc has been changed to cc.
[https://github.com/alexcrichton/cc-rs](https://github.com/alexcrichton/cc-rs)