### PR TITLE
Explicitly link the shell32.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -61,6 +61,7 @@ fn flavor_specifics(build: &mut cc::Build) {
     println!("cargo:rustc-link-lib=dylib=user32");
     println!("cargo:rustc-link-lib=dylib=gdi32");
     println!("cargo:rustc-link-lib=dylib=comdlg32");
+    println!("cargo:rustc-link-lib=dylib=shell32");
 
     build
         .file("src/PDCurses/win32a/pdcclip.c")


### PR DESCRIPTION
Changed to link explicitly because std crate no longer depends on the shell32.
This change of std crate does affect, currently the nightly only.

For details, please see https://github.com/rust-lang/rust/commit/81de5d9519270e1c9dc3c1ee97067ac7058edefe

- - -

I'm sorry. I forgot to write the reason for this change.

PDCurses Win32a uses shell32 's ExtractIconW function, but because std crate no longer links shell32, pdcurses- sys crate fails to link programs that use the win32a feature and use it.
