### PR TITLE
Fix broken link to pdcurses website in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pdcurses-sys [![Build status](https://ci.appveyor.com/api/projects/status/7quldtl11lsitu2v?svg=true)](https://ci.appveyor.com/project/ihalila/pdcurses-sys) [![Crates.io](https://img.shields.io/crates/v/pdcurses-sys.svg)](https://crates.io/crates/pdcurses-sys)
 
-pdcurses-sys provides Rust FFI bindings for [PDCurses](http://wmcbrine.com/pdcurses/),
+pdcurses-sys provides Rust FFI bindings for [PDCurses](https://pdcurses.org/),
 specifically the fork by [Bill-Gray](https://github.com/Bill-Gray/PDCurses).
 
 ## Requirements


### PR DESCRIPTION
Previously: http://wmcbrine.com/pdcurses/ (404 page)
Now: https://pdcurses.org/